### PR TITLE
ISSUE-41: Array only for «IgnoreInDest» option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Destination directory or directories.
   // Remove all files from dest that are not found in src. Default: true
   updateAndDelete: true,
   // Never remove js files from destination. Default: false
-  ignoreInDest: '**/*.js'
+  ignoreInDest: ['**/*.js']
 }
 ```
 

--- a/src/managers/options.ts
+++ b/src/managers/options.ts
@@ -17,7 +17,7 @@ export interface IOptions {
 	/**
 	 * Never remove specified files from destination directory.
 	 */
-	ignoreInDest: Pattern | Pattern[];
+	ignoreInDest: Pattern[];
 }
 
 export type IPartialOptions = Partial<IOptions>;
@@ -29,10 +29,6 @@ export function prepare(options?: IPartialOptions): IOptions {
 		updateAndDelete: true,
 		ignoreInDest: []
 	}, options);
-
-	if (options && options.ignoreInDest) {
-		opts.ignoreInDest = ([] as Pattern[]).concat(options.ignoreInDest);
-	}
 
 	return opts;
 }

--- a/src/syncy.spec.ts
+++ b/src/syncy.spec.ts
@@ -239,7 +239,7 @@ describe('Syncy', () => {
 	describe('Ignore files', () => {
 		it('ignore-0: Ignore `test-0.txt` in dest directory (ignoreInDest)', () => {
 			return createFiles('.tmp/ignore-0/fixtures', 1)
-				.then(() => syncy('fixtures/**', '.tmp/ignore-0', { ignoreInDest: '**/test-0.txt' }))
+				.then(() => syncy('fixtures/**', '.tmp/ignore-0', { ignoreInDest: ['**/test-0.txt'] }))
 				.then(() => readdir('.tmp/ignore-0'))
 				.then((result) => {
 					assert.equal(result.length, 9);
@@ -248,7 +248,7 @@ describe('Syncy', () => {
 
 		it('ignore-1: Don\'t remove directory with ignored files', () => {
 			return createFiles('.tmp/ignore-1/fixtures/main', 1)
-				.then(() => syncy('fixtures/**', '.tmp/ignore-1', { ignoreInDest: '**/*.txt' }))
+				.then(() => syncy('fixtures/**', '.tmp/ignore-1', { ignoreInDest: ['**/*.txt'] }))
 				.then(() => readdir('.tmp/ignore-1'))
 				.then((result) => {
 					assert.equal(result.length, 9);

--- a/src/syncy.ts
+++ b/src/syncy.ts
@@ -53,7 +53,7 @@ export function getSourceEntries(patterns: Pattern | Pattern[]): Promise<string[
  * Get all the parts of a file path for excluded paths.
  */
 export function getPartsOfExcludedPaths(destFiles: string[], options: IOptions): string[] {
-	return (<Pattern[]>options.ignoreInDest)
+	return options.ignoreInDest
 		.reduce((collection, pattern) => collection.concat(minimatch.match(destFiles, pattern, { dot: true })), [] as string[])
 		.map((filepath) => pathUtils.pathFromDestToSource(filepath, options.base))
 		.reduce((collection, filepath) => collection.concat(pathUtils.expandDirectoryTree(filepath)), [] as string[]);


### PR DESCRIPTION
#### Links

  * #41

#### What is?

  * Now `ignoreInDest` option works only with arrays.