### PR TITLE
Add allowOverwrite option that defaults to the value of updateAndDelete.

### DIFF
--- a/src/managers/options.spec.ts
+++ b/src/managers/options.spec.ts
@@ -9,6 +9,7 @@ describe('Managers → Options', () => {
 				verbose: false,
 				base: '',
 				updateAndDelete: true,
+				allowOverwrite: true,
 				ignoreInDest: []
 			};
 
@@ -22,10 +23,39 @@ describe('Managers → Options', () => {
 				verbose: false,
 				base: 'base',
 				updateAndDelete: true,
+				allowOverwrite: true,
 				ignoreInDest: []
 			};
 
 			const actual = manager.prepare({ base: 'base' });
+
+			assert.deepEqual(actual, expected);
+		});
+
+		it('should returns builded options for provided object with allowOverwrite implicitly defaulted', () => {
+			const expected: manager.IOptions = {
+				verbose: false,
+				base: '',
+				updateAndDelete: false,
+				allowOverwrite: false,
+				ignoreInDest: []
+			};
+
+			const actual = manager.prepare({ updateAndDelete: false });
+
+			assert.deepEqual(actual, expected);
+		});
+
+		it('should returns builded options for provided object with allowOverwrite explicitly set', () => {
+			const expected: manager.IOptions = {
+				verbose: false,
+				base: '',
+				updateAndDelete: false,
+				allowOverwrite: true,
+				ignoreInDest: []
+			};
+
+			const actual = manager.prepare({ updateAndDelete: false, allowOverwrite: true });
 
 			assert.deepEqual(actual, expected);
 		});

--- a/src/managers/options.ts
+++ b/src/managers/options.ts
@@ -15,6 +15,10 @@ export interface IOptions {
 	 */
 	updateAndDelete: boolean;
 	/**
+	 * Update files in `dest` that are found in `src`.
+	 */
+	allowOverwrite?: boolean;
+	/**
 	 * Never remove specified files from destination directory.
 	 */
 	ignoreInDest: Pattern[];
@@ -29,6 +33,10 @@ export function prepare(options?: IPartialOptions): IOptions {
 		updateAndDelete: true,
 		ignoreInDest: []
 	}, options);
+
+	if (!('allowOverwrite' in opts)) {
+		opts.allowOverwrite = opts.updateAndDelete;
+	}
 
 	return opts;
 }

--- a/src/syncy.ts
+++ b/src/syncy.ts
@@ -130,7 +130,7 @@ export async function run(patterns: Pattern[], dest: string, sourceFiles: string
 
 		const copyAction = Promise.all([statFrom, statDest]).then((stat) => {
 			// We should update this file?
-			if (skipUpdate(stat[0], stat[1], options.updateAndDelete)) {
+			if (skipUpdate(stat[0], stat[1], <boolean> options.allowOverwrite)) {
 				return;
 			}
 


### PR DESCRIPTION
Resolves #40 by adding a new option named "allowOverwrite".  This new option will default to the value of "updateAndDelete" if not provided.